### PR TITLE
add KSP-AVC version file for auto-module checking

### DIFF
--- a/EditorExtensions.version
+++ b/EditorExtensions.version
@@ -1,0 +1,14 @@
+{
+  "NAME": "EditorExtensions",
+  "URL": "https://raw.githubusercontent.com/MachXXV/EditorExtensions/master/EditorExtensions.version",
+  "VERSION": {
+    "MAJOR": 1,
+    "MINOR": 1,
+    "PATCH": 0
+  },
+  "KSP_VERSION": {
+    "MAJOR": 0,
+    "MINOR": 23,
+    "PATCH": 5
+  }
+}


### PR DESCRIPTION
Dearest EE authors/maintainers,

I just started working with @tyrope on a project to add a version checker to KSP modules. I know that it would help me a lot! He said that helping him contact module authors would be really helpful so here I am! If you would be willing to accept this patch we would really appreciate it!

The KSP Addon Version Checker is my attempt at trying to have some sort of version checking available for people who play KSP with lots of mods. more information and source available [right here on github](https://github.com/tyrope/KSP-addon-version-checker)

**Note**: I wasn't sure where to put this, I'm guessing you have a build process. I would be happy to make amendments to that process if you give me pointers in that direction. This file needs to be accessible online as well as somewhere in the GameData folder. Thank you!

PS. I use your mod every day and I don't think I could live without it. Thank you so much for your hard work!
