### PR TITLE
v1.2 - 0.24 position updates

### DIFF
--- a/EditorExtensions/EditorExtensions.cs
+++ b/EditorExtensions/EditorExtensions.cs
@@ -102,8 +102,8 @@ namespace EditorExtensions
 			editor.mirrorSprite.Hide(true);
 	
 			//Rects for symmetry/angle snap labels
-			symLabelRect = new Rect (70, Screen.height - 104, 50, 50);
-			angleSnapLabelRect = new Rect (137, Screen.height - 104, 50, 50);
+			symLabelRect = new Rect (143, Screen.height - 65, 57, 57);
+			angleSnapLabelRect = new Rect (201, Screen.height - 63, 46, 46);
 	
 			InitStyles ();
 	

--- a/EditorExtensions/Properties/AssemblyInfo.cs
+++ b/EditorExtensions/Properties/AssemblyInfo.cs
@@ -17,7 +17,7 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion("1.1.*")]
+[assembly: AssemblyVersion("1.2.*")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/EditorExtensions/Readme.html
+++ b/EditorExtensions/Readme.html
@@ -40,6 +40,11 @@
 <p>
 <h2>Version History</h2>
 
+<h3>1.2 - 18 July 2014</h3>
+<ul>
+	<li>Updated Text position for 0.24</li>
+</ul>
+
 <h3>1.1 - 2 April 2014</h3>
 <ul>
 	<li>Merged changes from forum user Ratzap</li>


### PR DESCRIPTION
Updated the positions of symmetry marker and angle-snap indicator for 0.24.

![ee-snap](https://cloud.githubusercontent.com/assets/285602/3624241/3619a1a2-0e5a-11e4-9bc1-24242397c4ee.png)
