### PR TITLE
Update EditorExtensions.cs

### DIFF
--- a/EditorExtensions/EditorExtensions.cs
+++ b/EditorExtensions/EditorExtensions.cs
@@ -188,7 +188,7 @@ namespace EditorExtensions
 			}
 	
 			// Alt+M - Toggle VAB/SPH editor mode (while staying in the same hangar)
-			if (Input.GetKeyDown(KeyCode.Tab))
+			if (Input.GetKeyDown(KeyCode.Y))
 			{
 				if (editor.editorType == EditorLogic.EditorMode.SPH){
 					editor.editorType = EditorLogic.EditorMode.VAB;


### PR DESCRIPTION
Changing the key to change between VAB and SPH to Y instead of Tab because Tab causes the craft name or description field to be focused which then eat up all following key presses.
